### PR TITLE
Use new DependencyFilter API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>com.vaadin</groupId>
 	<artifactId>webcomponents-helper</artifactId>
 	<packaging>jar</packaging>
-	<version>0.1-SNAPSHOT</version>
+	<version>0.2-SNAPSHOT</version>
 	<name>Helper for using Web Components with Framework 8.1</name>
 
 	<properties>

--- a/src/main/java/com/vaadin/webcomponentshelper/htmlbundle/HtmlBundleHandler.java
+++ b/src/main/java/com/vaadin/webcomponentshelper/htmlbundle/HtmlBundleHandler.java
@@ -25,7 +25,9 @@ import java.util.logging.Logger;
 import com.vaadin.server.BootstrapHandler;
 import com.vaadin.server.DependencyFilter;
 import com.vaadin.server.DeploymentConfiguration;
+import com.vaadin.server.ServiceInitEvent;
 import com.vaadin.server.VaadinService;
+import com.vaadin.server.VaadinServiceInitListener;
 import com.vaadin.server.VaadinServlet;
 import com.vaadin.server.VaadinServletService;
 import com.vaadin.server.VaadinSession;
@@ -36,13 +38,19 @@ import com.vaadin.ui.Dependency.Type;
  * Takes care of rewriting HTML resources into a HTML bundle, if such a bundle
  * is used.
  */
-public class HtmlBundleHandler implements DependencyFilter {
+public class HtmlBundleHandler
+        implements DependencyFilter, VaadinServiceInitListener {
 
     /**
      * Configuration name for the HTML bundle to use instead of individual HTML
      * imports.
      */
     public static final String HTML_BUNDLE_NAME = "html-bundle";
+
+    @Override
+    public void serviceInit(ServiceInitEvent event) {
+        event.addDependencyFilter(this);
+    }
 
     /**
      * Processes the given dependencies and replaces any suitable HTML import

--- a/src/main/resources/META-INF/services/com.vaadin.server.DependencyFilter
+++ b/src/main/resources/META-INF/services/com.vaadin.server.DependencyFilter
@@ -1,1 +1,0 @@
-com.vaadin.webcomponentshelper.htmlbundle.HtmlBundleHandler

--- a/src/main/resources/META-INF/services/com.vaadin.server.VaadinServiceInitListener
+++ b/src/main/resources/META-INF/services/com.vaadin.server.VaadinServiceInitListener
@@ -1,1 +1,2 @@
 com.vaadin.webcomponentshelper.polyfill.LoadPolyfill
+com.vaadin.webcomponentshelper.htmlbundle.HtmlBundleHandler


### PR DESCRIPTION
Use the new API for registering filters that was introduced in
https://github.com/vaadin/framework/pull/9368. Bumps the snapshot version
since the new API is not compatible with older framework versions.